### PR TITLE
fix: treat 0 as plural

### DIFF
--- a/src/mehrzahl.ts
+++ b/src/mehrzahl.ts
@@ -39,7 +39,7 @@ const formatGroupSyntax = (
 export const mz: MehrzahlFormatterFactory =
   (amount, delimiter = DEFAULT_DELIMITER) =>
   (strings, ...valuesToInterpolate) => {
-    const isPlural = amount > 1
+    const isPlural = amount !== 1
     const amountString = amount.toString()
 
     const interpolatedValues = valuesToInterpolate.map((value) => {


### PR DESCRIPTION
In speech, 0 is treated as plural (think "0 item**s**")