### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import { zm } from "mehrzahl"
 
 const template = zm`There {was|were} $value person{|s} at this event.`
 template(5) // There were 5 persons at this event.
-template(0) // There was 1 person at this event.
+template(1) // There was 1 person at this event.
 ```
 
 💡 `$value` is replaced by the amount specified.


### PR DESCRIPTION
The current example shows an incorrect example. The template called with 0 is shown to return the string that would result from a call with 1.

This PR fixes that typo (and apparently adds a trailing newline because GitHub).